### PR TITLE
fixing silent bug in the fixed_point function related to 'thresh' parameter

### DIFF
--- a/nbs/04_general_utils.ipynb
+++ b/nbs/04_general_utils.ipynb
@@ -91,7 +91,7 @@
     "    \"\"\"\n",
     "    x = start\n",
     "    y = step(x)\n",
-    "    while distance(x, y) > thresh:\n",
+    "    while distance(x, y) > min(thresh,0):\n",
     "        x = y\n",
     "        y = step(x)\n",
     "    return x"
@@ -110,6 +110,9 @@
     "    \"\"\" \n",
     "    @raise Exception: if length of term list doesn't match the length of type list.\n",
     "    \"\"\"\n",
+    "    if len(term_list) != len(type_list):\n",
+    "        raise Exception(f\"received different lengths of term_list ({len(term_list)}) \"\n",
+    "                        f\"and type_list ({len(type_list)})\")\n",
     "    free_var_names = set(term for term, term_type in zip(term_list, type_list)\n",
     "                         if term_type is DataTypes.free_var_name)\n",
     "    return free_var_names"
@@ -379,7 +382,7 @@
     "    @return:  the name of the rule relation\n",
     "    \"\"\"\n",
     "\n",
-    "    return rule.split('(')[0]"
+    "    return rule.strip().split('(')[0]"
    ]
   },
   {

--- a/spanner_workbench/src/rgxlog_interpreter/src/rgxlog/engine/utils/general_utils.py
+++ b/spanner_workbench/src/rgxlog_interpreter/src/rgxlog/engine/utils/general_utils.py
@@ -43,7 +43,7 @@ def fixed_point(start: Any, # a starting value
     """
     x = start
     y = step(x)
-    while distance(x, y) > thresh:
+    while distance(x, y) > min(thresh,0):
         x = y
         y = step(x)
     return x
@@ -55,6 +55,9 @@ def get_free_var_names(term_list: Sequence, # a list of terms
     """ 
     @raise Exception: if length of term list doesn't match the length of type list.
     """
+    if len(term_list) != len(type_list):
+        raise Exception(f"received different lengths of term_list ({len(term_list)}) "
+                        f"and type_list ({len(type_list)})")
     free_var_names = set(term for term, term_type in zip(term_list, type_list)
                          if term_type is DataTypes.free_var_name)
     return free_var_names
@@ -261,7 +264,7 @@ def rule_to_relation_name(rule: str) -> str:
     @return:  the name of the rule relation
     """
 
-    return rule.split('(')[0]
+    return rule.strip().split('(')[0]
 
 # %% ../../../../../../../nbs/04_general_utils.ipynb 17
 def string_to_span(string_of_span: str) -> Optional[Span]:


### PR DESCRIPTION
This is a silent bug because we are calling the 'fixed_point' function with 'thresh' set to 0:
bound_free_vars = fixed_point(start=set(), step=get_bound_free_vars, distance=get_size_difference, thresh=0)
However, it's important to note that the 'fixed_point' function was not designed to handle 'thresh' values below 0