### PR TITLE
corrected SQL template: replaced commas with 'AND' in WHERE clause

### DIFF
--- a/nbs/07_engine.ipynb
+++ b/nbs/07_engine.ipynb
@@ -387,7 +387,7 @@
     "        {% for left, right in constraint_pairs %}\n",
     "            {{left}}={{right}}\n",
     "            {% if not loop.last %}\n",
-    "                ,\n",
+    "                AND\n",
     "            {% endif %}\n",
     "        {% endfor %}\n",
     "        \"\"\")\n",

--- a/spanner_workbench/src/rgxlog_interpreter/src/rgxlog/engine/engine.py
+++ b/spanner_workbench/src/rgxlog_interpreter/src/rgxlog/engine/engine.py
@@ -316,7 +316,7 @@ class SqliteEngine(RgxlogEngineBase):
         {% for left, right in constraint_pairs %}
             {{left}}={{right}}
             {% if not loop.last %}
-                ,
+                AND
             {% endif %}
         {% endfor %}
         """)


### PR DESCRIPTION
we have addressed an issue in the SQL template.
previously, the template used commas (,) as separators between conditions in the WHERE clause. However, this is not the standard SQL syntax.